### PR TITLE
docs: README Edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Discord Oauth2의 "Guilds.join" Scope를 활용한 코드입니다.
 + 사용시 스타 한번씩 눌러주시면 감사하겠습니다 :)
 
 ## 사용법
-1. 이 코드를 clone(`git clone https://github.com/samsunghappytree123/discord-oauth2-guilds.join`) 또는 fork 등으로 다운로드합니다. 
-2. cmd에 ``pip install -r "requirements.txt"``를 사용해 필수적으로 설치해야 하는 의존성 모듈을 설치합니다.
+1. 이 코드를 Clone(`git clone https://github.com/samsunghappytree123/discord-oauth2-guilds.join`) 또는 Use This Template 혹은 Fork 등으로 다운로드합니다. 
+2. cmd에 ``python3 -m pip install -r "requirements.txt"``를 사용해 필수적으로 설치해야 하는 의존성 모듈을 설치합니다.
 3. [``.env.example``](.env.example) 파일을 참고하여 ``.env`` 파일을, [``config.py.example``](config.py.example)을 참고하여 ``config.py``를 만들어주세요. (상세한 예시는 [여기](#envexample과-configpyexample-내용-설명)를 확인해주세요.)
-4. ``python app.py``를 사용하여 [``app.py``](app.py)를 실행해주세요.
+4. ``python3 app.py``를 사용하여 [``app.py``](app.py)를 실행해주세요.
 5. ``${config.py HOST}/login``에 접속하여 인증을 테스트를 하세요.
 
 ---

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ OAUTH2_CLIENT_SECRET=YOUR_SECRET_KEY # 봇의 CLIENT_SECRET_KEY를 입력해주�
 GUILD_ID = 1234567890 # 강제 초대할 서버의 ID를 입력하세요.
 CLIENT_ID = 1234567890 # APPLICATION ID (BOT ID)를 입력해주세요.
 REDIRECT_URI = 'http://localhost:5000/callback' # OAUTH 로그인 후 이동할 웹사이트의 주소를 입력하세요.
-                                                # APPLICATION OAUTH 탭에서 REDIRECT URL을 http://[아이피]/callback으로 지정하세요!
+                                                # APPLICATION OAUTH 탭에서 REDIRECT URL을 이 부분에 입력한 주소로 지정하세요!
 
 # -- Sanic 호스트 설정 -- #
 HOST = '127.0.0.1' # 127.0.0.1과 같이 수정해주세요.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Discord Oauth2의 "Guilds.join" Scope를 활용한 코드입니다.
 
 ## 사용법
 1. 이 코드를 Clone(`git clone https://github.com/samsunghappytree123/discord-oauth2-guilds.join`) 또는 Use This Template 혹은 Fork 등으로 다운로드합니다. 
-2. cmd에 ``python3 -m pip install -r "requirements.txt"``를 사용해 필수적으로 설치해야 하는 의존성 모듈을 설치합니다.
+2. Terminal에 ``python3 -m pip install -r "requirements.txt"``를 사용해 필수적으로 설치해야 하는 의존성 모듈을 설치합니다.
 3. [``.env.example``](.env.example) 파일을 참고하여 ``.env`` 파일을, [``config.py.example``](config.py.example)을 참고하여 ``config.py``를 만들어주세요. (상세한 예시는 [여기](#envexample과-configpyexample-내용-설명)를 확인해주세요.)
 4. ``python3 app.py``를 사용하여 [``app.py``](app.py)를 실행해주세요.
 5. ``${config.py HOST}/login``에 접속하여 인증을 테스트를 하세요.


### PR DESCRIPTION
### 1. `python3 -m pip`로 사용하라는 Python3 권고사항 반영
### 2. `python3`으로 사용하라는 Python3 권고사항 반영
### 3. 리눅스/윈도우 모두 용어가 터미널로 통합되었으므로, cmd대신 터미널로 수정
### 4. Config 파일에 사용자가 혼동할 수 있는 문구 수정